### PR TITLE
removed refs to ST2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [phpfmt](https://github.com/phpfmt/fmt) support for Sublime Text 2/3
+# [phpfmt](https://github.com/phpfmt/fmt) support for Sublime Text 3
 
 ## Installation
 

--- a/README.src.md
+++ b/README.src.md
@@ -1,4 +1,4 @@
-# [phpfmt](https://github.com/phpfmt/fmt) support for Sublime Text 2/3
+# [phpfmt](https://github.com/phpfmt/fmt) support for Sublime Text 3
 
 ***[This project follows a Code of Conduct.](https://github.com/phpfmt/code-of-conduct)***
 


### PR DESCRIPTION
Since the package is now ST3-only, I took out the one remaining reference to ST2 in both README files, which [caused some confusion](http://stackoverflow.com/questions/38050293/sublime-text-2s-phpfmt-plugin-is-not-available-anymore).
